### PR TITLE
[Update] Update build-opae.sh to use latest opae-sim

### DIFF
--- a/common/scripts/build-opae.sh
+++ b/common/scripts/build-opae.sh
@@ -121,7 +121,8 @@ if [ -n "$OFS_ASP_ENV_ENABLE_ASE" ]; then
     fi
     # Default branch to 'master' if the branch variable is not set
     if [ -z "${OPAESIM_REPO_BRANCH}" ]; then
-        OPAESIM_REPO_BRANCH="release/2.5.0"
+        #OPAESIM_REPO_BRANCH="release/2.5.0"
+        OPAESIM_REPO_BRANCH="master"
     fi
     # Default location to clone is $BUILD_PREFIX/opae-sim
     if [ -z "${OPAESIM_PATH}" ]; then


### PR DESCRIPTION
### Description
Change the default opae-sim branch to simply be 'master' in order to leverage recent updates and fixes.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
ASE boardtest and zcdt.

